### PR TITLE
Added extra_compile_args to setup.py for GNU99 standard.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ import shutil
 fftlog_module = Extension( name="pycl2xi._fftlog",
                            sources=["src/fftlog.c"],
                            depends=["src/fftlog.h"],
-                           libraries=["fftw3"]
+                           libraries=["fftw3"],
+                           extra_compile_args=["-std=gnu99"]
                            )
 
 class Uninstall(DistutilsInstall):


### PR DESCRIPTION
As noted in issue #1 I needed to pass extra_compile_args to enforce the GNU99/C99 standard in order to compile without complaints on both macOS and Ubuntu.